### PR TITLE
Correct the persistence of homescreen columns

### DIFF
--- a/apps/homescreen/js/firstrun.js
+++ b/apps/homescreen/js/firstrun.js
@@ -149,6 +149,13 @@
           var small = !!(json.preferences && json.preferences[COLS_PREF] &&
             (json.preferences[COLS_PREF] > 3));
 
+          // update data store
+          navigator.getDataStores(HOMESCREEN_SETTINGS).then(stores => {
+            stores[0].put(small ? 6 : 3, COLS_PREF);
+          }).catch(e => {
+            console.error('Error storing homescreen cols setting', e);
+          });
+
           var order = [];
           if (json.grid) {
             var index = 0;

--- a/apps/homescreen/js/settings.js
+++ b/apps/homescreen/js/settings.js
@@ -43,10 +43,16 @@
 
         var syncSmallSetting = (signal) => {
           stores[0].get(COLUMNS_SETTING).then(cols => {
-            var oldSmall = this.small;
-            this.small = cols > 3;
-            if (this.small !== oldSmall) {
-              signalChange();
+            if (cols) {
+              var oldSmall = this.small;
+              this.small = cols > 3;
+              if (this.small !== oldSmall) {
+                signalChange();
+              }
+            } else {
+              stores[0].add(this.small ? 6 : 3, COLUMNS_SETTING).catch(e => {
+                console.error('Error storing homescreen cols setting', e);
+              });
             }
           });
         };


### PR DESCRIPTION
This is only patching. Homescreen reads settings from:
- verticalhome datastore
- json from distrib
- its own datastore
- its local storage
  All these happens in several places, and there is concurrency issue depending on if we run the firsttime.js file... This is a mess ! Atleast here we will correctly persist the setting of the distrib.

@peppsac please R?
